### PR TITLE
Adapt color palettes

### DIFF
--- a/R/hgch_dumbbell_CatNumNum.R
+++ b/R/hgch_dumbbell_CatNumNum.R
@@ -24,7 +24,7 @@ hgch_dumbbell_CatNumNum <- function(data, ...){
     if(opts$title$ver_title == ""){
       title_y <- opts$title$ver_title}}
 
-  palette <- paletero::paletero(c("high", "low"), opts$theme$palette_colors)
+  palette <- paletero::paletero(c("high", "low"), l$theme$palette_colors)
 
   dat <- data
   names(dat) <- c("category", "low", "high")

--- a/R/hgch_prep.R
+++ b/R/hgch_prep.R
@@ -3,10 +3,10 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
 
   if (is.null(data)) return()
 
-  palette <- opts$theme$palette_colors
-  if(is.null(palette)){
-    palette <- opts$theme$palette_colors_categorical
+  if(is.null(opts$theme$palette_colors)){
+    opts$theme$palette_colors <- opts$theme$palette_colors_categorical
   }
+  palette <- opts$theme$palette_colors
 
   f <- homodatum::fringe(data)
   nms <- homodatum::fringe_labels(f)

--- a/R/hgch_prep.R
+++ b/R/hgch_prep.R
@@ -3,6 +3,11 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
 
   if (is.null(data)) return()
 
+  palette <- opts$theme$palette_colors
+  if(is.null(palette)){
+    palette <- opts$theme$palette_colors_categorical
+  }
+
   f <- homodatum::fringe(data)
   nms <- homodatum::fringe_labels(f)
   d <- fringe_d(f)
@@ -60,12 +65,11 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
     ver_title <- as.character(labelsXY[2])
 
     if (grepl("Dat", frtype)) {
-      d$..colors <- opts$theme$palette_colors[1]
+      d$..colors <- palette[1]
       min_date <- min(d$a)
       d$group <- nms[[2]]
     } else {
       color_by <- names(nms[match(opts$style$color_by, nms)])
-      palette <- opts$theme$palette_colors
       d$..colors <- paletero::map_colors(d, color_by, palette, colors_df = NULL)
     }
 
@@ -119,7 +123,6 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
       d <- completevalues(d)
     }
 
-    palette <- opts$theme$palette_colors
     d$..colors <- paletero::map_colors(d, 'a', palette, colors_df = NULL)
 
     if (!is.null(opts$chart$highlight_value)) {

--- a/R/hgch_sankey_CatCat.R
+++ b/R/hgch_sankey_CatCat.R
@@ -11,8 +11,11 @@ hgch_sankey_CatCat <- function(data, ...){
 
   if (is.null(data)) stop(" dataset to visualize")
   opts <- dsvizopts::merge_dsviz_options(...)
+
   palette <- opts$theme$palette_colors
-  opts$theme$palette_colors <- dsvizopts::default_theme_opts()$palette_colors
+  if(is.null(palette)){
+    palette <- opts$theme$palette_colors_categorical
+  }
 
   data_dummy <- data[,1:2] %>% mutate_all(~paste0(., "_dummy"))
   l <- hgchmagic_prep(data_dummy, opts = opts)


### PR DESCRIPTION
Adapting the way color palettes are assigned because the default of `palette_colors` is now NULL. 

If there is no user input for `palette_colors` this change makes sure that `palette_colors_categorical` is used by default.