### PR TITLE
Temporary fix for sankey

### DIFF
--- a/R/hgch_prep.R
+++ b/R/hgch_prep.R
@@ -86,14 +86,16 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
   dic_alt <- dic
 
   if (agg_var == "..count") {
-    dic_p <- dic_p %>% bind_rows(  bind_rows(data.frame(id = "..count", label = "Count", hdType = "Num")))
+    dic_p <- dic_p %>% bind_rows(  bind_rows(data.frame(id = "..count", label = "Count", hdType = "Num") %>%
+                                               mutate_all(as.character)))
   } else {
     dic_p <- dic_p
   }
 
   if (opts$postprocess$percentage) {
     dic_p <- dic_p %>% filter(id != agg_var)
-    dic_p <- dic_p %>% bind_rows(  bind_rows(data.frame(id = "..percentage", label = "%", hdType = "Num")))
+    dic_p <- dic_p %>% bind_rows(  bind_rows(data.frame(id = "..percentage", label = "%", hdType = "Num") %>%
+                                               mutate_all(as.character)))
   }
 
 
@@ -128,7 +130,8 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
 
       if (grepl("Dat", ftype)) {
         dic_p <- dic_p %>%
-          bind_rows(data.frame(id = "..group", label = "..group", hdType = "Cat"))
+          bind_rows(data.frame(id = "..group", label = "..group", hdType = "Cat") %>%
+                      mutate_all(as.character))
         nms[length(nms)+1] <- c("..group")
         names(nms) <- c(names(nms)[-length(nms)], "..group")
       }
@@ -203,7 +206,8 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
       dn[[f_cats]]
     })
     dic_alt <- dic_alt %>%
-              bind_rows(data.frame(id = c("..count", "..percentage"), label = c("Count", "%"), hdType = c("Num", "Num")))
+              bind_rows(data.frame(id = c("..count", "..percentage"), label = c("Count", "%"), hdType = c("Num", "Num")) %>%
+                          mutate_all(as.character))
 
     d <- dd %>% left_join(dn, by = var_g)
   }

--- a/R/hgch_prep.R
+++ b/R/hgch_prep.R
@@ -292,7 +292,6 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
 
   # color -------------------------------------------------------------------
 
-  palette <- opts$theme$palette_colors
   palette_type <- opts$theme$palette_type %||% "categorical"
 
   color_by <- NULL
@@ -301,9 +300,10 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
   if (sum(grepl("Dat|Cat|Yea", ftype_vec)) == 2) color_by <- "a"
 
 
-  if(is.null(palette)){
-    palette <- opts$theme[[paste0("palette_colors_", palette_type)]]
+  if(is.null(opts$theme$palette_colors)){
+    opts$theme$palette_colors <- opts$theme[[paste0("palette_colors_", palette_type)]]
   }
+  palette <- opts$theme$palette_colors
 
   if ("color" %in% dic$hdType) {
     d$..colors <- d[[dic$id[dic$hdType == "color"][1]]]

--- a/R/hgch_sankey_CatCat.R
+++ b/R/hgch_sankey_CatCat.R
@@ -42,8 +42,7 @@ hgch_sankey_CatCat <- function(data, ...){
 
   nodes_unique <- unique(c(unique(data_sankey_format$from_label), unique(data_sankey_format$to_label)))
 
-  colors <- data.frame(name = nodes_unique) %>%
-    mutate(color = paletero::paletero(name, as.character(palette)))
+  colors <- data.frame(name = nodes_unique, color = paletero::paletero(nodes_unique, as.character(palette)))
 
   if(!is.null(names(palette))){
     colors <- data.frame(name = nodes_unique) %>%

--- a/R/hgch_sankey_CatCat.R
+++ b/R/hgch_sankey_CatCat.R
@@ -42,7 +42,8 @@ hgch_sankey_CatCat <- function(data, ...){
 
   nodes_unique <- unique(c(unique(data_sankey_format$from_label), unique(data_sankey_format$to_label)))
 
-  colors <- data.frame(name = nodes_unique, color = paletero::paletero(nodes_unique, as.character(palette)))
+  colors <- data.frame(name = nodes_unique, color = paletero::paletero(nodes_unique, as.character(palette))) %>%
+    mutate_all(as.character)
 
   if(!is.null(names(palette))){
     colors <- data.frame(name = nodes_unique) %>%
@@ -139,7 +140,7 @@ hgch_sankey_CatCat <- function(data, ...){
       )) %>%
     hc_tooltip(pointFormatter = JS("
     function() {
-      var result = this.from + ' \u2192 ' + this.to +
+      var result = this.from_label + ' \u2192 ' + this.to_label +
                    '<br>Total: <b>' + this.weight + '</b>' +
                    '<br>Percentage: <b>' + this.pct + '</b>';
       return result;


### PR DESCRIPTION
Suggested changes for the `feature/tooltip_changes` branch to temporarily fix the sankey chart. 

It still doesn't work with the data from `hgch_prep` but with data that's generated separately in `hgch_sankey_CatCat`. That's because including the sankey data formatting in `hgch_prep` will be a longer process and this way we can merge the changes from this branch for now.