### PR TITLE
Fix namespaces after merge

### DIFF
--- a/R/hgch_bubbles_CatCatNum.R
+++ b/R/hgch_bubbles_CatCatNum.R
@@ -54,7 +54,7 @@ hgch_bubbles_CatCatNum <- function(data, ...){
     label_info <- d0 %>% .$labels %>% unlist()
     l0 <- list("name" = i,
                "color" = unique(d0$..colors),
-               "data" = map(seq_along(d0[[3]]), function(i){
+               "data" = purrr::map(seq_along(d0[[3]]), function(i){
                  list("label" =  label_info[i],
                       "value" = d0[[3]][i]
                  )

--- a/R/hgch_line_CatDatNum.R
+++ b/R/hgch_line_CatDatNum.R
@@ -44,10 +44,10 @@ hgch_line_CatDatNum <- function(data, ...){
   ds <- NULL
   series <- lapply(unique(d$a), function(s){
 
-    ds <<- d %>% filter(a == s)
-    dss <- ds %>% select(a,b, labels)
+    ds <<- d %>% dplyr::filter(a == s)
+    dss <- ds %>% dplyr::select(a,b, labels)
     dss <- dss %>%
-      mutate(x = as.numeric(ds$b),
+      dplyr::mutate(x = as.numeric(ds$b),
              y = ds[[3]],
              label = labels)
     list(

--- a/R/hgch_line_DatNum.R
+++ b/R/hgch_line_DatNum.R
@@ -44,13 +44,13 @@ hgch_line_DatNum <- function(data, ...){
   ds <- NULL
 
   series <- lapply(unique(d$..group), function(s){
-    ds <<- d %>% filter(..group == s)
+    ds <<- d %>% dplyr::filter(..group == s)
     dss <- ds[,c(1, 2, 4)]
     dss <- ds %>%
-      mutate(x = ds$a,
-             y = ds[[2]],
-             color = ds$..colors,
-             label = labels)
+      dplyr::mutate(x = ds$a,
+                    y = ds[[2]],
+                    color = ds$..colors,
+                    label = labels)
 
     list(
       name = s,

--- a/R/hgch_scatter_CatDatNum.R
+++ b/R/hgch_scatter_CatDatNum.R
@@ -30,12 +30,12 @@ hgch_scatter_CatDatNum <- function(data, ...){
   ds <- NULL
   series <- lapply(unique(d$a), function(s){
 
-    ds <<- d %>% filter(a == s)
-    dss <- ds %>% select(a,b, labels)
+    ds <<- d %>% dplyr::filter(a == s)
+    dss <- ds %>% dplyr::select(a,b, labels)
     dss <- dss %>%
-      mutate(x = as.numeric(ds$b),
-             y = ds[[3]],
-             label = labels)
+      dplyr::mutate(x = as.numeric(ds$b),
+                    y = ds[[3]],
+                    label = labels)
 
     list(
       name = s,

--- a/R/hgch_scatter_CatNumNum.R
+++ b/R/hgch_scatter_CatNumNum.R
@@ -35,12 +35,12 @@ hgch_scatter_CatNumNum <- function(data, ...){
   ds <- NULL
   series <- lapply(unique(d$a), function(s){
 
-    ds <<- d %>% filter(a == s)
-    dss <- ds %>% select(a,b, labels)
+    ds <<- d %>% dplyr::filter(a == s)
+    dss <- ds %>% dplyr::select(a,b, labels)
     dss <- dss %>%
-      mutate(x = as.numeric(ds$b),
-             y = ds[[3]],
-             label = labels)
+      dplyr::mutate(x = as.numeric(ds$b),
+                    y = ds[[3]],
+                    label = labels)
     list(
       name = s,
       color = unique(ds$..colors),

--- a/R/hgch_scatter_DatNum.R
+++ b/R/hgch_scatter_DatNum.R
@@ -28,13 +28,13 @@ hgch_scatter_DatNum <- function(data, ...){
   ds <- NULL
 
   series <- lapply(unique(d$..group), function(s){
-    ds <<- d %>% filter(..group == s)
+    ds <<- d %>% dplyr::filter(..group == s)
     dss <- ds[,c(1, 2, 4)]
     dss <- ds %>%
-      mutate(x = ds$a,
-             y = ds[[2]],
-             color = ds$..colors,
-             label = labels)
+      dplyr::mutate(x = ds$a,
+                    y = ds[[2]],
+                    color = ds$..colors,
+                    label = labels)
     list(
       name = s,
       color = ds$..colors[1],

--- a/R/hgch_scatter_NumNum.R
+++ b/R/hgch_scatter_NumNum.R
@@ -41,7 +41,7 @@ hgch_scatter_NumNum <- function(data, ...){
   d <- l$d
 
 
-  data_list <- map(1:nrow(d), function(z) {
+  data_list <- purrr::map(1:nrow(d), function(z) {
     list(x = d$a[z],
          y = d$b[z],
          color = d$..colors[z],


### PR DESCRIPTION
Some of the namespace fixes were lost in the rebase of the `tooltip_changes` branch. In this PR they are fixed again.