### PR TITLE
Fix summarise across to summarise all

### DIFF
--- a/R/hgch_prep.R
+++ b/R/hgch_prep.R
@@ -127,7 +127,7 @@ hgchmagic_prep <- function(data, opts = NULL, extra_pattern = ".", plot =  "bar"
 
       dn <- dn %>%
         dplyr::group_by(a) %>%
-        dplyr::summarise(dplyr::across(.cols = dplyr::everything(), .fns = func_paste))
+        dplyr::summarise_all(.funs = func_paste)
 
       if (grepl("Dat", ftype)) {
         dic_p <- dic_p %>%


### PR DESCRIPTION
In `hgch_prep` a `summarise` function was called with `across`. This failed when there was no other column except for the `group_by` column. Changing it to use `summarise_all` without `across` fixed the issue.